### PR TITLE
Add adabanium jar name to the adabranium.toml file

### DIFF
--- a/mods/adabranium.toml
+++ b/mods/adabranium.toml
@@ -3,6 +3,6 @@ filename = "adabraniummod-2.0.0+20w48a.jar"
 side = "both"
 
 [download]
-url = "https://raw.githubusercontent.com/Queerbric/queerpack/1.17/mods/.jar"
+url = "https://raw.githubusercontent.com/Queerbric/queerpack/1.17/mods/adabraniummod-2.0.0+20w51a.jar"
 hash-format = "sha256"
 hash = "394d437b2ee6fe64f7be57a9564c0618dc1b2e7bbf38105a0eaec893a4fa26fb"


### PR DESCRIPTION
I couldn't launch the pack, so here's a possible fix?